### PR TITLE
Match URL Only for Salesforce Lightning

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
       "content_scripts": [
         {
           "matches": [
-            "<all_urls>"
+            "*://*.lightning.force.com/*"
           ],
           "run_at": "document_end",
           "js": ["queueR.js"]


### PR DESCRIPTION
Updating the `manifest.json` so that the refresh click is only attempted when on the Salesforce Lightning URLs:
`*://*.lightning.force.com/*`

Found that it was previously attempting on all pages.

Tested this and it continues to work for our Salesforce Lightning Queues at least while not attempting on other domains.