### PR TITLE
fix for Salesforce Winter 2020

### DIFF
--- a/queueR.js
+++ b/queueR.js
@@ -1,7 +1,7 @@
 window.onload = function () { 
 
 	function qRefresh() {
-		document.querySelector("#split-left > div > div > div > div > div.slds-page-header--object-home.slds-page-header_joined.slds-page-header_bleed.slds-page-header.slds-shrink-none.test-headerRegion.forceListViewManagerHeader > div:nth-child(2) > div:nth-child(3) > force-list-view-manager-button-bar > div > div:nth-child(1) > lightning-button-icon > button").click();
+		document.querySelector('#split-left').querySelector('button[name="refreshButton"]').click();
 	}
 
 	setInterval(function() {


### PR DESCRIPTION
The previous DOM selector was having issues recently and I believe it is related to the following issue:
https://developer.salesforce.com/forums/?id=9062I000000XkGYQA0

In summary, it appears to be something to do with Shadow DOM presentation and a change they made in "Salesforce Winter 2020."

This PR should resolve the browser error that was received with the previous selector:
```
Uncaught TypeError: Cannot read property 'click' of null
```

It is resolved by updating the selector to first find `#split-left` then find the refresh button.
This seems to do the trick when testing as we get a good consistent refresh now.

I'm not sure if Salesforce is doing a slow rollout of this, but I think this new selector should work in either case.

